### PR TITLE
Fix parentDocSlug for Connectors

### DIFF
--- a/guides/integrations-connectors/analytics-connector.md
+++ b/guides/integrations-connectors/analytics-connector.md
@@ -1,7 +1,7 @@
 ---
 title: Analytics Connector
 category: 652e408346c8860073a6bd12
-parentDocSlug: Connectors
+parentDocSlug: connectors
 
 ---
 

--- a/guides/integrations-connectors/erp-connectors.md
+++ b/guides/integrations-connectors/erp-connectors.md
@@ -1,7 +1,7 @@
 ---
 title: ERP Connectors
 category: 652e408346c8860073a6bd12
-parentDocSlug: Connectors
+parentDocSlug: connectors
 
 
 ---

--- a/guides/integrations-connectors/trackunit-connector.md
+++ b/guides/integrations-connectors/trackunit-connector.md
@@ -1,7 +1,7 @@
 ---
 title: Trackunit Connector
 category: 652e408346c8860073a6bd12
-parentDocSlug: Connectors
+parentDocSlug: connectors
 
 
 ---


### PR DESCRIPTION
Github Actions reported:

    Error: Error uploading guides/integrations-connectors/analytics-connector.md:

    We couldn't save this doc (Unable to find a parent doc with the slug 'Connectors').

Slack thread: https://trackunit.slack.com/archives/C03AS21A4AG/p1725445637802909