### PR TITLE
Remove the mention of "use cases" and "cpabilities" from IrisX docs

### DIFF
--- a/guides/ai-ml/ai-ml-overview.md
+++ b/guides/ai-ml/ai-ml-overview.md
@@ -3,14 +3,14 @@ title: AI & Machine Learning Overview
 category: 66c49b3dd9c1e0004aceb297
 ---
 
+![AI & ML with IrisX](https://cdn.statically.io/gh/trackunit/developer-hub/master/guides/ai-ml/ai-irisX.png)
+
 Take the next step with advanced modeling techniques, such as ML, LLMs and GenAI, to analyze data, identify patterns, and generate predictive insights to support and drive decision-making. IrisX offers tools for model training, deployment, and management with strict data privacy. It’s easy to get started start with all necessary models and tools, while maintaining end-to-end data privacy.
 
 ## What is AI & Machine Learning?
 AI & ML allow customer to run AI & ML algorithms with tools for model training, deployment, and management in a sandboxed and secure environment. IrisX ensures strict data privacy, making it easy to get started with all necessary models and tools while maintaining end-to-end data security that is more and more important to our customers.
 
-![AI & ML with IrisX](https://cdn.statically.io/gh/trackunit/developer-hub/master/guides/ai-ml/ai-irisX.png)
-
-## Features & Capabilities
+## Features
 - Data management, model training, and deployment in a single toolchain, reducing complexity.
 - Build, deploy, and monitor diverse AI and ML models with secure, cost-effective data integration.
 - Flexible access to leading LLMs entirely run within your private workspace.
@@ -22,14 +22,11 @@ AI & ML allow customer to run AI & ML algorithms with tools for model training, 
 - **Shared Feature Store**: Customers use IrisX to establish a centralized feature store streamlining the development process, improving model accuracy, and reducing time-to-production
 - **Model Training**: Customers use IrisX to develop accurate and efficient machine learning models of any type, ensuring the best possible performance across a variety of applications
 
-
 ### Deploy
 - Centralized Deployment: Customers use IrisX to deploy models seamlessly and efficiently as their centralized deployment system ensuring consistency, reliability, and scalability in production
 
 ### Use and feedback
 - Real-time Monitoring: Tools for monitoring model performance and data quality, with proactive alerting and detailed dashboards.
 - E2E Privacy & Security: Customers own their private instance that is fully secured by the highest security standards while retaining full data and model ownership
-
-
 
 IrisX leverages traditional ML and Gen AI to analyse data and identify patterns that humans would’t be able to - and now with Gen AI this is much more accesible to our customers.


### PR DESCRIPTION
I got feedback from Sebastian and we decided to remove those words from the IrisX docs for now.