### PR TITLE
Adds changelog for filters-filter-bar v1.7.90 about filters url sync

### DIFF
--- a/changelogs/filters-filter-bar-v1-7-90.md
+++ b/changelogs/filters-filter-bar-v1-7-90.md
@@ -1,0 +1,14 @@
+---
+title: trackunit/filters-filter-bar v1.7.90 - Filter URL Synchronization
+type: improved
+---
+
+## Filter URL Synchronization
+
+Filter states are now automatically synchronized with URL parameters, allowing users to bookmark or share filtered views. When filters are applied, the URL updates to reflect the current filter state, and the filters are restored when navigating back to that URL.
+
+### Breaking Change
+
+**TanStack Router is now required** for Iris app extensions using the filter bar. 
+
+Your app entry point must be wrapped with TanStack Router's `RouterProvider`. See the [iris-app-with-router-example](https://github.com/csk-trackunit/iris-app-with-router-example/blob/main/libs/context-test/src/index.tsx) for a complete implementation example showing how to set up the router in your Iris app extension.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds changelog for filters-filter-bar v1.7.90 describing filter URL synchronization and a breaking TanStack Router requirement.
> 
> - **Changelog** (`changelogs/filters-filter-bar-v1-7-90.md`):
>   - **Feature**: Filters sync with URL parameters; state restored from URL.
>   - **Breaking**: Requires TanStack Router; app must wrap entry with `RouterProvider` (see example link).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c18d5020a29ff7823fbdbfb588020437a6a3e55f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->