### PR TITLE
Upgrades readme client to v10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,36 +11,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync API docs
-        # We recommend specifying a fixed version, i.e. @v8
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v10
         with:
           rdme: docs ./api-docs --key=${{ secrets.README_API_KEY }} --version=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync Guides
-        # We recommend specifying a fixed version, i.e. @v8
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v10
         with:
           rdme: docs ./guides --key=${{ secrets.README_API_KEY }} --version=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync custom pages docs
-        # We recommend specifying a fixed version, i.e. @v8
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v10
         with:
           rdme: custompages ./custompages --key=${{ secrets.README_API_KEY }}
 
       # Run GitHub Action to sync changelogs in `changelog` directory
       - name: Sync changelog pages docs
-        # We recommend specifying a fixed version, i.e. @v8
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v10
         with:
           rdme: changelogs ./changelogs --key=${{ secrets.README_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades the docs sync workflow to use actions/checkout@v4 and readmeio/rdme@v10 across all steps.
> 
> - **CI/Workflow** (`.github/workflows/main.yml`):
>   - Bump `actions/checkout` from `v3` to `v4`.
>   - Upgrade `readmeio/rdme` from `v8` to `v10` for:
>     - API docs sync
>     - Guides sync
>     - Custom pages sync
>     - Changelogs sync
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0efb6c80ac4d1fec5d0939e69d152dc745d1c9d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->