### PR TITLE
rdme client v9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./api-docs --key=${{ secrets.README_API_KEY }} --branch=1.0
+          rdme: docs ./api-docs --key=${{ secrets.README_API_KEY }} --version=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync Guides
@@ -27,7 +27,7 @@ jobs:
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./guides --key=${{ secrets.README_API_KEY }} --branch=1.0
+          rdme: docs ./guides --key=${{ secrets.README_API_KEY }} --version=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync custom pages docs
@@ -35,7 +35,7 @@ jobs:
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@v10
         with:
-          rdme: custompages upload ./custompages --key=${{ secrets.README_API_KEY }}
+          rdme: custompages ./custompages --key=${{ secrets.README_API_KEY }}
 
       # Run GitHub Action to sync changelogs in `changelog` directory
       - name: Sync changelog pages docs
@@ -43,4 +43,4 @@ jobs:
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@v10
         with:
-          rdme: changelog upload ./changelogs --key=${{ secrets.README_API_KEY }}
+          rdme: changelogs ./changelogs --key=${{ secrets.README_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,32 +15,32 @@ jobs:
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync API docs
-        # We recommend specifying a fixed version, i.e. @v10
+        # We recommend specifying a fixed version, i.e. @v9
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v10
+        uses: readmeio/rdme@v9
         with:
           rdme: docs ./api-docs --key=${{ secrets.README_API_KEY }} --version=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync Guides
-        # We recommend specifying a fixed version, i.e. @v10
+        # We recommend specifying a fixed version, i.e. @v9
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v10
+        uses: readmeio/rdme@v9
         with:
           rdme: docs ./guides --key=${{ secrets.README_API_KEY }} --version=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync custom pages docs
-        # We recommend specifying a fixed version, i.e. @v10
+        # We recommend specifying a fixed version, i.e. @v9
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v10
+        uses: readmeio/rdme@v9
         with:
           rdme: custompages ./custompages --key=${{ secrets.README_API_KEY }}
 
       # Run GitHub Action to sync changelogs in `changelog` directory
       - name: Sync changelog pages docs
-        # We recommend specifying a fixed version, i.e. @v10
+        # We recommend specifying a fixed version, i.e. @v9
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v10
+        uses: readmeio/rdme@v9
         with:
           rdme: changelogs ./changelogs --key=${{ secrets.README_API_KEY }}


### PR DESCRIPTION
- **Revert "upgrade readme client (#325)"**
- **Downgrades cli to v9 since its recommended it not using ReadMe Refactored (whatever that is)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades `readmeio/rdme` action to v9 and updates CLI flags/commands across docs sync steps.
> 
> - **CI Workflow** (`.github/workflows/main.yml`):
>   - Downgrade `uses: readmeio/rdme@v10` to `@v9` for all docs sync steps.
>   - Update `rdme` invocations:
>     - API docs and Guides: `docs upload ... --branch=1.0` -> `docs ... --version=1.0`.
>     - Custom pages: `custompages upload ...` -> `custompages ...`.
>     - Changelogs: `changelog upload ...` -> `changelogs ...`.
>   - Adjust accompanying comments to reference v9.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b8daa77d840adbfab5c32088adf2ef5e715766e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->