### PR TITLE
Revert "rdme client v9"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,32 +15,32 @@ jobs:
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync API docs
-        # We recommend specifying a fixed version, i.e. @v9
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v9
+        uses: readmeio/rdme@v10
         with:
-          rdme: docs ./api-docs --key=${{ secrets.README_API_KEY }} --version=1.0
+          rdme: docs upload ./api-docs --key=${{ secrets.README_API_KEY }} --branch=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync Guides
-        # We recommend specifying a fixed version, i.e. @v9
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v9
+        uses: readmeio/rdme@v10
         with:
-          rdme: docs ./guides --key=${{ secrets.README_API_KEY }} --version=1.0
+          rdme: docs upload ./guides --key=${{ secrets.README_API_KEY }} --branch=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync custom pages docs
-        # We recommend specifying a fixed version, i.e. @v9
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v9
+        uses: readmeio/rdme@v10
         with:
-          rdme: custompages ./custompages --key=${{ secrets.README_API_KEY }}
+          rdme: custompages upload ./custompages --key=${{ secrets.README_API_KEY }}
 
       # Run GitHub Action to sync changelogs in `changelog` directory
       - name: Sync changelog pages docs
-        # We recommend specifying a fixed version, i.e. @v9
+        # We recommend specifying a fixed version, i.e. @v10
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@v9
+        uses: readmeio/rdme@v10
         with:
-          rdme: changelogs ./changelogs --key=${{ secrets.README_API_KEY }}
+          rdme: changelog upload ./changelogs --key=${{ secrets.README_API_KEY }}


### PR DESCRIPTION
Reverts Trackunit/developer-hub#327 back to v10 of the client.
Next step is to validate the docs and upload a single low risk doc to see if it breaks the hierarchy 