### PR TITLE
Should use 'reference' cmd to upload api-docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./api-docs --key=${{ secrets.README_API_KEY }} --branch=1.0
+          rdme: reference upload ./api-docs --key=${{ secrets.README_API_KEY }} --branch=1.0
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: Sync Guides


### PR DESCRIPTION
The commands have been updated to the following:

    rdme docs upload (or rdme reference upload if you're uploading
Markdown to your API Reference section)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch ReadMe action to use `rdme reference upload` for `./api-docs` in the main workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6be261715b6eacb305aada89eaab4b37a6f81b74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->