### PR TITLE
Fixes yet another MDX error

### DIFF
--- a/changelogs/iris-app-v0-0-645.md
+++ b/changelogs/iris-app-v0-0-645.md
@@ -6,6 +6,6 @@ type: improved
 In this version of the Iris App SDK, we have added a requirement to accept
 developer terms and conditions when publishing an Iris app.
 
-Read the developer terms and conditions here: <https://trackunit.com/terms-conditions-marketplace/>
+[Read the developer terms and conditions here.](https://trackunit.com/terms-conditions-marketplace/)
 
 Please refer to [How to Submit an App](https://developers.trackunit.com/docs/iris-app-publish) for more information.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Converts the terms-and-conditions URL to a Markdown link in `changelogs/iris-app-v0-0-645.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79d5dcd7ed6f41717bc0ffb85d841c276e547858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->