### PR TITLE
Modify CODEOWNERS to update team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,18 +6,4 @@
 
 # these owners will be requested for review when someone opens a pull request.
 
-/.github/CODEOWNERS @sieker-trackunit
-
-/guides/ @KateVomBerg
-/api-docs/ @KateVomBerg
-/custompages/ @KateVomBerg
-/changelogs/ @KateVomBerg
-
-/guides/sdk-docs/ @Trackunit/team-iris-foundation @Trackunit/team-gluon-fe @KateVomBerg
-/custompages/graphql-visualizer.md @Trackunit/team-iris-foundation
-
-/api-docs/data-model.md @Trackunit/team-rio
-/api-docs/machine-insights-streaming-dataformat.md @Trackunit/team-rio
-/api-docs/streaming-api.md @Trackunit/team-rio
-/custompages/iso-feeds.md @Trackunit/team-rio
-
+/.github/CODEOWNERS @Trackunit/team-iris-foundation


### PR DESCRIPTION
Updated CODEOWNERS to change ownership for the repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `CODEOWNERS` to only assign `/.github/CODEOWNERS` to `@Trackunit/team-iris-foundation`, removing prior path-specific owners.
> 
> - **Repo ownership**:
>   - Change `/.github/CODEOWNERS` owner to `@Trackunit/team-iris-foundation`.
>   - Remove previous path-specific owners for `guides/`, `api-docs/`, `custompages/`, `changelogs/`, and various files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0b5929f2f03c37e99476dd24a30ecbee37a74e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->